### PR TITLE
Fix publishing configuration and export paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,11 +11,15 @@
         }
     },
     "publishConfig": {
-        "@testsigmainc:registry": "https://npm.pkg.github.com"
+        "registry": "https://npm.pkg.github.com"
     },
+    "files": [
+        "dist",
+        "src"
+    ],
     "scripts": {
         "build": "babel src --out-dir dist --copy-files",
-        "prepublish": "npm run build"
+        "prepublishOnly": "npm run build"
     },
     "keywords": [
         "react",
@@ -36,6 +40,9 @@
         "url": "https://github.com/TestsigmaInc/react-log-file-viewer/issues"
     },
     "homepage": "https://github.com/TestsigmaInc/react-log-file-viewer#readme",
+    "engines": {
+        "node": ">=16.0.0"
+    },
     "peerDependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata to specify required Node.js version (16.0.0 or higher).
  * Adjusted publishing configuration and registry settings.
  * Explicitly included the dist and src directories in published files.
  * Renamed the prepublish script to prepublishOnly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->